### PR TITLE
fix(notifications): DM notifications not being sent to recipients

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ fail_fast: false
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
         files: "raven.*"
@@ -18,21 +18,21 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.34.0
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         files: "raven.*"
         args: ["--py310-plus"]
 
   - repo: https://github.com/adityahase/black
-    rev: 9cb0a69f4d0030cdf687eddf314468b39ed54119
+    rev: 22.1.0
     hooks:
       - id: black
         files: "raven.*"
         additional_dependencies: ["click==8.0.4"]
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 7.3.0
     hooks:
       - id: flake8
         files: "raven.*"
@@ -40,7 +40,7 @@ repos:
         args: ["--config", ".github/helper/flake8.conf"]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+    rev: 7.0.0
     hooks:
       - id: isort
         files: "raven.*"

--- a/raven/notification.py
+++ b/raven/notification.py
@@ -56,6 +56,10 @@ def send_push_notification_via_raven_cloud(message, raven_settings):
             if is_dm_or_dm_thread or member.get("allow_notifications") == 1:
                 users.append(member.get("user_id"))
 
+        frappe.log_error(
+            title="DM Debug - Users",
+            message=f"users: {users}",
+        )
         if not users:
             return
 

--- a/raven/notification.py
+++ b/raven/notification.py
@@ -56,10 +56,6 @@ def send_push_notification_via_raven_cloud(message, raven_settings):
             if is_dm_or_dm_thread or member.get("allow_notifications") == 1:
                 users.append(member.get("user_id"))
 
-        frappe.log_error(
-            title="DM Debug - Users",
-            message=f"users: {users}",
-        )
         if not users:
             return
 

--- a/raven/notification.py
+++ b/raven/notification.py
@@ -12,344 +12,374 @@ MAX_NOTIFICATION_CONTENT_LENGTH = 1000
 
 
 def send_notification_for_message(message):
-	"""
-	Send a push notification for a message.
+    """
+    Send a push notification for a message.
 
-	This is called in the "after_response" hook for user initiated requests.
-	"""
+    This is called in the "after_response" hook for user initiated requests.
+    """
 
-	raven_settings = frappe.get_cached_doc("Raven Settings")
+    raven_settings = frappe.get_cached_doc("Raven Settings")
 
-	if raven_settings.push_notification_service == "Raven":
-		send_push_notification_via_raven_cloud(message, raven_settings)
+    if raven_settings.push_notification_service == "Raven":
+        send_push_notification_via_raven_cloud(message, raven_settings)
 
-		return
+        return
 
-	channel_doc = frappe.get_cached_doc("Raven Channel", message.channel_id)
-	if channel_doc.is_direct_message and not channel_doc.is_self_message:
-		message.send_notification_for_direct_message()
+    channel_doc = frappe.get_cached_doc("Raven Channel", message.channel_id)
+    if channel_doc.is_direct_message and not channel_doc.is_self_message:
+        message.send_notification_for_direct_message()
 
-	else:
-		message.send_notification_for_channel_message()
+    else:
+        message.send_notification_for_channel_message()
 
 
 def send_push_notification_via_raven_cloud(message, raven_settings):
-	"""
-	Send a push notification via the Raven Cloud API
-	"""
-	channel_doc = frappe.get_cached_doc("Raven Channel", message.channel_id)
+    """
+    Send a push notification via the Raven Cloud API
+    """
+    channel_doc = frappe.get_cached_doc("Raven Channel", message.channel_id)
 
-	if channel_doc.is_self_message:
-		return
+    if channel_doc.is_self_message:
+        return
 
-	try:
+    try:
 
-		channel_members = get_channel_members(message.channel_id)
+        channel_members = get_channel_members(message.channel_id)
+        frappe.log_error(
+            title="DM Debug - Channel Members",
+            message=f"channel_id: {message.channel_id}, channel_members: {channel_members}",
+        )
 
-		users = []
+        users = []
 
-		# Loop over the channel members and add the users who have subscribed to push notifications
-		for member in channel_members.values():
-			if member.get("allow_notifications"):
-				users.append(member.get("user_id"))
+        # Loop over the channel members and add the users who have subscribed to push notifications
+        for member in channel_members.values():
+            frappe.log_error(
+                title="DM Debug - Channel Member",
+                message=f"member: {member.get('user_id')}, allow_notifications: {member.get('allow_notifications')}",
+            )
+            if member.get("allow_notifications") == 1:
+                users.append(member.get("user_id"))
 
-		if not users:
-			return
+        frappe.log_error(
+            title="DM Debug - Users",
+            message=f"users: {users}",
+        )
 
-		mentions = [user.get("user") for user in message.mentions]
+        if not users:
+            return
 
-		replied_to = None
+        mentions = [user.get("user") for user in message.mentions]
 
-		if message.linked_message:
-			replied_message_details = message.replied_message_details
+        replied_to = None
 
-			if isinstance(replied_message_details, str):
-				replied_message_details = json.loads(message.replied_message_details)
+        if message.linked_message:
+            replied_message_details = message.replied_message_details
 
-			replied_to = replied_message_details.get("owner")
+            if isinstance(replied_message_details, str):
+                replied_message_details = json.loads(message.replied_message_details)
 
-		mentioned_users = []
-		replied_users = []
-		final_users = []
+            replied_to = replied_message_details.get("owner")
 
-		# If this is a bot message, then we should not filter out the push tokens of the message owner since we need to send the notification to the owner as well (it's coming from the bot)
-		if not message.is_bot_message:
-			# Filter out the push tokens of the message owner
-			users = [user for user in users if user != message.owner]
+        mentioned_users = []
+        replied_users = []
+        final_users = []
 
-		for user in users:
-			if user == replied_to:
-				replied_users.append(user)
-			elif user in mentions:
-				mentioned_users.append(user)
-			else:
-				final_users.append(user)
+        # If this is a bot message, then we should not filter out the push tokens of the message owner since we need to send the notification to the owner as well (it's coming from the bot)
+        if not message.is_bot_message:
+            # Filter out the push tokens of the message owner
+            users = [user for user in users if user != message.owner]
 
-		# We now need to construct the payload for the push notification
+        for user in users:
+            if user == replied_to:
+                replied_users.append(user)
+            elif user in mentions:
+                mentioned_users.append(user)
+            else:
+                final_users.append(user)
 
-		if not mentioned_users and not replied_users and not final_users:
-			return
+        # We now need to construct the payload for the push notification
 
-		messages = []
+        if not mentioned_users and not replied_users and not final_users:
+            return
 
-		channel_name = f" in #{channel_doc.channel_name}"
+        messages = []
 
-		if channel_doc.is_thread:
-			channel_name = " in thread"
+        channel_name = f" in #{channel_doc.channel_name}"
 
-		if channel_doc.is_direct_message:
-			channel_name = ""
+        if channel_doc.is_thread:
+            channel_name = " in thread"
 
-		content = message.get_notification_message_content()
+        if channel_doc.is_direct_message:
+            channel_name = ""
 
-		# Truncate the message content to fit within FCM payload limits
-		truncated_content = truncate_notification_content(content)
+        content = message.get_notification_message_content()
 
-		message_owner, message_owner_image = message.get_message_owner_details()
+        # Truncate the message content to fit within FCM payload limits
+        truncated_content = truncate_notification_content(content)
 
-		workspace = "" if channel_doc.is_dm_thread else channel_doc.workspace
+        message_owner, message_owner_image = message.get_message_owner_details()
 
-		url = frappe.utils.get_url() + "/raven/"
-		if workspace:
-			url += f"{workspace}/"
-		else:
-			url += "channels/"
+        workspace = "" if channel_doc.is_dm_thread else channel_doc.workspace
 
-		if channel_doc.is_thread:
-			url += f"thread/{channel_doc.name}/"
-		else:
-			url += f"{channel_doc.name}/"
+        url = frappe.utils.get_url() + "/raven/"
+        if workspace:
+            url += f"{workspace}/"
+        else:
+            url += "channels/"
 
-		image = get_image_absolute_url(message_owner_image)
+        if channel_doc.is_thread:
+            url += f"thread/{channel_doc.name}/"
+        else:
+            url += f"{channel_doc.name}/"
 
-		data = {
-			"base_url": frappe.utils.get_url(),
-			"message_url": url,
-			"sitename": frappe.local.site,
-			"message_id": message.name,
-			"channel_id": message.channel_id,
-			"raven_message_type": message.message_type,
-			"channel_type": "DM" if channel_doc.is_direct_message else "Channel",
-			"content": truncated_content,
-			"from_user": message.owner,
-			"type": "New message",
-			"is_thread": "1" if channel_doc.is_thread else "0",
-			"creation": get_milliseconds_since_epoch(message.creation),
-			"image": image if image else "",
-		}
+        image = get_image_absolute_url(message_owner_image)
 
-		if replied_users:
-			messages.append(
-				{
-					"users": replied_users,
-					"notification": {
-						"title": f"{message_owner} replied{channel_name}",
-						"body": truncated_content,
-					},
-					"data": data,
-					"tag": message.channel_id,
-					"click_action": url,
-					"image": image,
-				}
-			)
+        data = {
+            "base_url": frappe.utils.get_url(),
+            "message_url": url,
+            "sitename": frappe.local.site,
+            "message_id": message.name,
+            "channel_id": message.channel_id,
+            "raven_message_type": message.message_type,
+            "channel_type": "DM" if channel_doc.is_direct_message else "Channel",
+            "content": truncated_content,
+            "from_user": message.owner,
+            "type": "New message",
+            "is_thread": "1" if channel_doc.is_thread else "0",
+            "creation": get_milliseconds_since_epoch(message.creation),
+            "image": image if image else "",
+        }
 
-		if mentioned_users:
-			messages.append(
-				{
-					"users": mentioned_users,
-					"notification": {
-						"title": f"{message_owner} mentioned you{channel_name}",
-						"body": truncated_content,
-					},
-					"data": data,
-					"tag": message.channel_id,
-					"click_action": url,
-					"image": image,
-				}
-			)
+        if replied_users:
+            messages.append(
+                {
+                    "users": replied_users,
+                    "notification": {
+                        "title": f"{message_owner} replied{channel_name}",
+                        "body": truncated_content,
+                    },
+                    "data": data,
+                    "tag": message.channel_id,
+                    "click_action": url,
+                    "image": image,
+                }
+            )
 
-		if final_users:
-			messages.append(
-				{
-					"users": final_users,
-					"notification": {"title": f"{message_owner}{channel_name}", "body": truncated_content},
-					"data": data,
-					"tag": message.channel_id,
-					"click_action": url,
-					"image": image,
-				}
-			)
+        if mentioned_users:
+            messages.append(
+                {
+                    "users": mentioned_users,
+                    "notification": {
+                        "title": f"{message_owner} mentioned you{channel_name}",
+                        "body": truncated_content,
+                    },
+                    "data": data,
+                    "tag": message.channel_id,
+                    "click_action": url,
+                    "image": image,
+                }
+            )
 
-		make_post_call_for_notification(messages, raven_settings)
+        if final_users:
+            messages.append(
+                {
+                    "users": final_users,
+                    "notification": {
+                        "title": f"{message_owner}{channel_name}",
+                        "body": truncated_content,
+                    },
+                    "data": data,
+                    "tag": message.channel_id,
+                    "click_action": url,
+                    "image": image,
+                }
+            )
 
-	except Exception as e:
-		frappe.log_error(title="Raven Cloud Push Notification Error")
+        frappe.log_error(
+            title="DM Debug - Messages End",
+            message=f"messages: {json.dumps(messages)}",
+        )
+
+        make_post_call_for_notification(messages, raven_settings)
+
+    except Exception as e:
+        frappe.log_error(title="Raven Cloud Push Notification Error")
 
 
 def make_post_call_for_notification(messages, raven_settings):
-	"""
-	Make a post call to the push notification server to send the notification
-	"""
+    """
+    Make a post call to the push notification server to send the notification
+    """
 
-	client = FrappeClient(
-		url=raven_settings.push_notification_server_url,
-		api_key=raven_settings.push_notification_api_key,
-		api_secret=raven_settings.get_password("push_notification_api_secret"),
-	)
+    client = FrappeClient(
+        url=raven_settings.push_notification_server_url,
+        api_key=raven_settings.push_notification_api_key,
+        api_secret=raven_settings.get_password("push_notification_api_secret"),
+    )
 
-	client.post_api(
-		"raven_cloud.api.notification.send_to_users",
-		params={
-			"messages": json.dumps(messages),
-			"site_name": urlparse(frappe.utils.get_url()).hostname,
-		},
-	)
+    client.post_api(
+        "raven_cloud.api.notification.send_to_users",
+        params={
+            "messages": json.dumps(messages),
+            "site_name": urlparse(frappe.utils.get_url()).hostname,
+        },
+    )
 
 
 # The below functions are used to send push notifications via the Frappe Push Notification Service
 
 
 def send_notification_to_user(user_id, title, message, data=None, user_image_path=None):
-	"""
-	Send a push notification to a user
-	"""
+    """
+    Send a push notification to a user
+    """
 
-	try:
-		from frappe.push_notification import PushNotification
+    try:
+        from frappe.push_notification import PushNotification
 
-		push_notification = PushNotification("raven")
+        push_notification = PushNotification("raven")
 
-		if data is None:
-			data = {"base_url": frappe.utils.get_url(), "sitename": frappe.local.site}
-		else:
-			data["base_url"] = frappe.utils.get_url()
-			data["sitename"] = frappe.local.site
+        if data is None:
+            data = {"base_url": frappe.utils.get_url(), "sitename": frappe.local.site}
+        else:
+            data["base_url"] = frappe.utils.get_url()
+            data["sitename"] = frappe.local.site
 
-		if push_notification.is_enabled():
-			icon_url = get_image_absolute_url(user_image_path)
-			link = None
-			if data.get("channel_id"):
-				link = frappe.utils.get_url() + "/raven/channel/" + data.get("channel_id", "")
-			push_notification.send_notification_to_user(
-				user_id=user_id, title=title, body=message, icon=icon_url, data=data, link=link
-			)
-	except ImportError:
-		# push notifications are not supported in the current framework version
-		pass
-	except Exception:
-		frappe.log_error("Failed to send push notification")
+        if push_notification.is_enabled():
+            icon_url = get_image_absolute_url(user_image_path)
+            link = None
+            if data.get("channel_id"):
+                link = frappe.utils.get_url() + "/raven/channel/" + data.get("channel_id", "")
+            push_notification.send_notification_to_user(
+                user_id=user_id, title=title, body=message, icon=icon_url, data=data, link=link
+            )
+    except ImportError:
+        # push notifications are not supported in the current framework version
+        pass
+    except Exception:
+        frappe.log_error("Failed to send push notification")
 
 
 def send_notification_to_topic(channel_id, title, message, data=None, user_image_path=None):
-	"""
-	Send a push notification to a channel
-	"""
+    """
+    Send a push notification to a channel
+    """
 
-	try:
-		from frappe.push_notification import PushNotification
+    try:
+        from frappe.push_notification import PushNotification
 
-		push_notification = PushNotification("raven")
+        push_notification = PushNotification("raven")
 
-		if data is None:
-			data = {"base_url": frappe.utils.get_url(), "sitename": frappe.local.site}
-		else:
-			data["base_url"] = frappe.utils.get_url()
-			data["sitename"] = frappe.local.site
+        if data is None:
+            data = {"base_url": frappe.utils.get_url(), "sitename": frappe.local.site}
+        else:
+            data["base_url"] = frappe.utils.get_url()
+            data["sitename"] = frappe.local.site
 
-		if push_notification.is_enabled():
-			icon_url = get_image_absolute_url(user_image_path)
-			link = None
-			if data.get("channel_id"):
-				link = frappe.utils.get_url() + "/raven/channel/" + data.get("channel_id", "")
-			push_notification.send_notification_to_topic(
-				topic_name=channel_id, title=title, body=message, icon=icon_url, data=data, link=link
-			)
-	except ImportError:
-		# push notifications are not supported in the current framework version
-		pass
-	except Exception:
-		frappe.log_error("Failed to send push notification")
+        if push_notification.is_enabled():
+            icon_url = get_image_absolute_url(user_image_path)
+            link = None
+            if data.get("channel_id"):
+                link = frappe.utils.get_url() + "/raven/channel/" + data.get("channel_id", "")
+            push_notification.send_notification_to_topic(
+                topic_name=channel_id,
+                title=title,
+                body=message,
+                icon=icon_url,
+                data=data,
+                link=link,
+            )
+    except ImportError:
+        # push notifications are not supported in the current framework version
+        pass
+    except Exception:
+        frappe.log_error("Failed to send push notification")
 
 
 def subscribe_user_to_topic(channel_id, user_id):
-	"""
-	Subscribe a user to a topic (channel name)
-	"""
-	notification_service = frappe.db.get_single_value("Raven Settings", "push_notification_service")
+    """
+    Subscribe a user to a topic (channel name)
+    """
+    notification_service = frappe.db.get_single_value(
+        "Raven Settings", "push_notification_service"
+    )
 
-	if notification_service == "Raven":
-		return
+    if notification_service == "Raven":
+        return
 
-	try:
-		from frappe.push_notification import PushNotification
+    try:
+        from frappe.push_notification import PushNotification
 
-		push_notification = PushNotification("raven")
+        push_notification = PushNotification("raven")
 
-		if push_notification.is_enabled():
-			push_notification.subscribe_topic(user_id=user_id, topic_name=channel_id)
-	except ImportError:
-		# push notifications are not supported in the current framework version
-		pass
-	except Exception:
-		frappe.log_error("Failed to subscribe user to channel")
+        if push_notification.is_enabled():
+            push_notification.subscribe_topic(user_id=user_id, topic_name=channel_id)
+    except ImportError:
+        # push notifications are not supported in the current framework version
+        pass
+    except Exception:
+        frappe.log_error("Failed to subscribe user to channel")
 
 
 def unsubscribe_user_to_topic(channel_id, user_id):
-	"""
-	Unsubscribe a user to a topic (channel name)
-	"""
-	notification_service = frappe.db.get_single_value("Raven Settings", "push_notification_service")
+    """
+    Unsubscribe a user to a topic (channel name)
+    """
+    notification_service = frappe.db.get_single_value(
+        "Raven Settings", "push_notification_service"
+    )
 
-	if notification_service == "Raven":
-		return
+    if notification_service == "Raven":
+        return
 
-	try:
-		from frappe.push_notification import PushNotification
+    try:
+        from frappe.push_notification import PushNotification
 
-		push_notification = PushNotification("raven")
+        push_notification = PushNotification("raven")
 
-		if push_notification.is_enabled():
-			push_notification.unsubscribe_topic(user_id=user_id, topic_name=channel_id)
-	except ImportError:
-		# push notifications are not supported in the current framework version
-		pass
-	except Exception:
-		frappe.log_error("Failed to unsubscribe user to channel")
+        if push_notification.is_enabled():
+            push_notification.unsubscribe_topic(user_id=user_id, topic_name=channel_id)
+    except ImportError:
+        # push notifications are not supported in the current framework version
+        pass
+    except Exception:
+        frappe.log_error("Failed to unsubscribe user to channel")
 
 
 def get_image_absolute_url(image_path):
-	if not image_path:
-		return None
+    if not image_path:
+        return None
 
-	if image_path.startswith("/"):
-		return frappe.utils.get_url() + image_path
-	else:
-		return image_path
+    if image_path.startswith("/"):
+        return frappe.utils.get_url() + image_path
+    else:
+        return image_path
 
 
 def get_milliseconds_since_epoch(timestamp: str) -> str:
-	"""
-	Returns the milliseconds since epoch for a given timestamp
-	"""
-	datetime_obj = get_datetime(timestamp)
+    """
+    Returns the milliseconds since epoch for a given timestamp
+    """
+    datetime_obj = get_datetime(timestamp)
 
-	# Localize the datetime object to system timezone
-	time_zone = get_system_timezone()
-	system_datetime = timezone(time_zone).localize(datetime_obj)
+    # Localize the datetime object to system timezone
+    time_zone = get_system_timezone()
+    system_datetime = timezone(time_zone).localize(datetime_obj)
 
-	# Convert the system datetime to UTC
-	utc_datetime = system_datetime.astimezone(utc)
+    # Convert the system datetime to UTC
+    utc_datetime = system_datetime.astimezone(utc)
 
-	# Get the timestamp in milliseconds since epoch for the UTC datetime
-	seconds_since_epoch = utc_datetime.timestamp()
-	return str(seconds_since_epoch * 1000)
+    # Get the timestamp in milliseconds since epoch for the UTC datetime
+    seconds_since_epoch = utc_datetime.timestamp()
+    return str(seconds_since_epoch * 1000)
 
 
 def truncate_notification_content(content):
-	"""
-	Truncate the push notification message content to fit within FCM payload limits
-	"""
-	if not content:
-		return
+    """
+    Truncate the push notification message content to fit within FCM payload limits
+    """
+    if not content:
+        return
 
-	return content[:MAX_NOTIFICATION_CONTENT_LENGTH]
+    return content[:MAX_NOTIFICATION_CONTENT_LENGTH]

--- a/raven/notification.py
+++ b/raven/notification.py
@@ -45,26 +45,16 @@ def send_push_notification_via_raven_cloud(message, raven_settings):
     try:
 
         channel_members = get_channel_members(message.channel_id)
-        frappe.log_error(
-            title="DM Debug - Channel Members",
-            message=f"channel_id: {message.channel_id}, channel_members: {channel_members}",
-        )
 
         users = []
 
         # Loop over the channel members and add the users who have subscribed to push notifications
         for member in channel_members.values():
-            frappe.log_error(
-                title="DM Debug - Channel Member",
-                message=f"member: {member.get('user_id')}, allow_notifications: {member.get('allow_notifications')}",
-            )
-            if member.get("allow_notifications") == 1:
+            is_dm_or_dm_thread = channel_doc.is_direct_message or channel_doc.is_dm_thread
+            # if the channel is a DM or DM thread, then we should add all the users to the list by default
+            # the allow notifications field would be used in future when we expose this setting in the UI to provide an option to the user to opt-out of push notifications for a certain DM user
+            if is_dm_or_dm_thread or member.get("allow_notifications") == 1:
                 users.append(member.get("user_id"))
-
-        frappe.log_error(
-            title="DM Debug - Users",
-            message=f"users: {users}",
-        )
 
         if not users:
             return


### PR DESCRIPTION
Problem -
Allow Notification flag in Raven Channel Member can be disabled (by default), since the flow for channels and DMs is the same, we did not skip the "allow_notification" check part earlier for DMs.

P.S -
We will need to expose this setting in the UI as well, so that user has the option to disable notifications for certain DMs.