### PR TITLE
feat: link search and preview improvement

### DIFF
--- a/apps/web/src/components/features/channel/ChannelHeader/ChannelMenu.tsx
+++ b/apps/web/src/components/features/channel/ChannelHeader/ChannelMenu.tsx
@@ -10,7 +10,6 @@ import {
     DropdownMenuTrigger,
 } from "@components/ui/dropdown-menu";
 import { useChannel } from "@hooks/useChannel";
-import { useCurrentChannelID } from "@hooks/useCurrentChannelID";
 import { channelDrawerAtom } from "@utils/channelAtoms";
 import { useSetAtom } from "jotai";
 import {
@@ -20,6 +19,9 @@ import {
     ChevronDown,
     Settings,
     Users,
+    Files,
+    Link,
+    MessageSquareText
 } from "lucide-react";
 import _ from "@lib/translate";
 
@@ -44,8 +46,11 @@ const ChannelMenu = ({ channelID }: { channelID: string }) => {
                 </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start" className="w-64">
-                <SettingsButton />
-                <MembersButton />
+                <SettingsButton channelID={channelID} />
+                <ChannelFilesButton channelID={channelID} />
+                <ChannelLinksButton channelID={channelID} />
+                <ChannelThreadsButton channelID={channelID} />
+                <MembersButton channelID={channelID} />
                 <DropdownMenuSub>
                     <DropdownMenuSubTrigger className="flex cursor-pointer items-center gap-2 py-2 text-sm">
                         <Bell className="h-4 w-4 text-muted-foreground" />
@@ -80,9 +85,7 @@ const ChannelMenu = ({ channelID }: { channelID: string }) => {
     )
 }
 
-const SettingsButton = () => {
-
-    const channelID = useCurrentChannelID()
+const SettingsButton = ({ channelID }: { channelID: string }) => {
 
     const setDrawerType = useSetAtom(channelDrawerAtom(channelID))
 
@@ -93,14 +96,54 @@ const SettingsButton = () => {
     return (
         <DropdownMenuItem className="flex cursor-pointer items-center gap-2 py-2 text-sm" onClick={onOpenSettings}>
             <Settings className="h-4 w-4" />
-            <span>{_("Channel details")}</span>
+            <span>{_("Channel info")}</span>
         </DropdownMenuItem>
     )
 }
 
-const MembersButton = () => {
+const ChannelFilesButton = ({ channelID }: { channelID: string }) => {
 
-    const channelID = useCurrentChannelID()
+    const setDrawerType = useSetAtom(channelDrawerAtom(channelID))
+
+    const onOpenFiles = () => {
+        setDrawerType('files')
+    }
+
+    return <DropdownMenuItem className="flex cursor-pointer items-center gap-2 py-2 text-sm" onClick={onOpenFiles}>
+        <Files className="h-4 w-4" />
+        <span>{_("Channel files")}</span>
+    </DropdownMenuItem>
+}
+
+const ChannelLinksButton = ({ channelID }: { channelID: string }) => {
+
+    const setDrawerType = useSetAtom(channelDrawerAtom(channelID))
+
+    const onOpenLinks = () => {
+        setDrawerType('links')
+    }
+
+    return <DropdownMenuItem className="flex cursor-pointer items-center gap-2 py-2 text-sm" onClick={onOpenLinks}>
+        <Link className="h-4 w-4" />
+        <span>{_("Channel links")}</span>
+    </DropdownMenuItem>
+}
+
+const ChannelThreadsButton = ({ channelID }: { channelID: string }) => {
+
+    const setDrawerType = useSetAtom(channelDrawerAtom(channelID))
+
+    const onOpenThreads = () => {
+        setDrawerType('threads')
+    }
+
+    return <DropdownMenuItem className="flex cursor-pointer items-center gap-2 py-2 text-sm" onClick={onOpenThreads}>
+        <MessageSquareText className="h-4 w-4" />
+        <span>{_("Channel threads")}</span>
+    </DropdownMenuItem>
+}
+
+const MembersButton = ({ channelID }: { channelID: string }) => {
 
     const setDrawerType = useSetAtom(channelDrawerAtom(channelID))
 

--- a/apps/web/src/components/features/channel/ChannelSettingsDrawer/ChannelLinks.tsx
+++ b/apps/web/src/components/features/channel/ChannelSettingsDrawer/ChannelLinks.tsx
@@ -1,5 +1,5 @@
 import { ScrollArea } from '@components/ui/scroll-area'
-import { Search, ExternalLink, Link } from 'lucide-react'
+import { Search, ExternalLink, Link, FileBox } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { SearchResult, useSqliteSearch } from '@hooks/useSqliteSearch'
 import { useFrappePostCall, useFrappeEventListener } from 'frappe-react-sdk'
@@ -16,6 +16,7 @@ export type LinkPreviewData = {
     description?: string
     image?: string
     site_name?: string
+    document_id?: string
 }
 
 function parsePreviews(previewDataJson?: string): LinkPreviewData[] {
@@ -37,9 +38,16 @@ const ChannelLinks = ({ channelID }: { channelID: string }) => {
     const { members } = useChannelMembers(channelID)
     const [searchQuery, setSearchQuery] = useState('')
 
-    const { results, isLoading, error, mutate } = useSqliteSearch(searchQuery, {
+    const longEnoughSearchQuery = useMemo(() => {
+        if (searchQuery.trim().length > 3) {
+            return searchQuery
+        }
+        return ""
+    }, [searchQuery])
+
+    const { results, isLoading, error, mutate } = useSqliteSearch(longEnoughSearchQuery, {
         channel_id: channelID,
-        has_link: 1
+        has_link: 1,
     }, 100)
 
     useFrappeEventListener("link_previews_updated", (data: { channel_id: string }) => {
@@ -48,6 +56,7 @@ const ChannelLinks = ({ channelID }: { channelID: string }) => {
         }
     })
 
+
     const { previews, previewlessUrls } = useMemo(() => {
         const previews: RichPreview[] = []
         const previewlessUrlSet = new Set<string>()
@@ -55,7 +64,11 @@ const ChannelLinks = ({ channelID }: { channelID: string }) => {
         if (results) {
             for (const link of results) {
                 for (const [index, preview] of parsePreviews(link.preview_data).entries()) {
-                    previews.push({ link, preview, index })
+                    if (longEnoughSearchQuery) {
+                        previews.push({ link, preview, index })
+                    } else if (!searchQuery.trim() || preview.title?.toLowerCase().includes(searchQuery.toLowerCase())) {
+                        previews.push({ link, preview, index })
+                    }
                     if (!preview.title) {
                         previewlessUrlSet.add(preview.url)
                     }
@@ -64,7 +77,7 @@ const ChannelLinks = ({ channelID }: { channelID: string }) => {
         }
 
         return { previews, previewlessUrls: [...previewlessUrlSet] }
-    }, [results])
+    }, [results, searchQuery])
 
     const { call: updatePreviewLinks } = useFrappePostCall('raven.api.preview_links.update_link_previews_in_background')
     const backfillFired = useRef(false)
@@ -155,6 +168,7 @@ const LinkPreviewCard = ({ link, preview, member }: {
     const hostname = new URL(url).hostname;
     const faviconUrl = `https://icons.duckduckgo.com/ip2/${hostname}.ico`;
     const displayTitle = preview?.title || url
+    const displaySubtitle = preview?.document_id ? preview.document_id : (preview?.site_name || hostname)
 
     return (
         <div
@@ -166,24 +180,26 @@ const LinkPreviewCard = ({ link, preview, member }: {
 
             <div className="space-y-2">
                 <div className="flex items-start gap-3">
-                    {faviconUrl ? (
+                    {preview.document_id ? (
+                        <FileBox className="w-5 h-5 shrink-0 text-muted-foreground" />
+                    ) : faviconUrl ? (
                         <img
                             src={faviconUrl}
                             alt=""
-                            className="w-5 h-5 shrink-0 mt-0.5"
+                            className="w-5 h-5 shrink-0"
                             onError={(e) => {
                                 e.currentTarget.style.display = 'none';
                                 e.currentTarget.nextElementSibling?.classList.remove('hidden');
                             }}
                         />)
                         : null}
-                    <Link className="w-5 h-5 shrink-0 text-muted-foreground mt-0.5 hidden" />
+                    <Link className="w-5 h-5 shrink-0 text-muted-foreground hidden" />
                     <div className="flex-1 min-w-0">
                         <h3 className="text-sm font-medium text-foreground truncate">
                             {displayTitle}
                         </h3>
                         <div className="text-xs text-muted-foreground/70 mt-0.5">
-                            {preview?.site_name || hostname}
+                            {displaySubtitle}
                         </div>
                     </div>
                     <ExternalLink className="h-3 w-3 text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-primary transition-opacity duration-200 shrink-0 mt-0.5" onClick={() => window.open(url, '_blank')} />

--- a/apps/web/src/components/features/channel/ChannelSettingsDrawer/ChannelLinks.tsx
+++ b/apps/web/src/components/features/channel/ChannelSettingsDrawer/ChannelLinks.tsx
@@ -1,24 +1,80 @@
 import { ScrollArea } from '@components/ui/scroll-area'
-import { Search, ExternalLink, LayoutPanelTop, Rows4, Link } from 'lucide-react'
-import { useState } from 'react'
+import { Search, ExternalLink, Link } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { SearchResult, useSqliteSearch } from '@hooks/useSqliteSearch'
+import { useFrappePostCall, useFrappeEventListener } from 'frappe-react-sdk'
 import _ from '@lib/translate'
-import { useLinkPreview } from '@raven/lib/hooks/useLinkPreview'
 import { Skeleton } from '@components/ui/skeleton'
 import { ChannelMemberData, useChannelMembers } from '@hooks/useChannelMembers'
 import { UserAvatar } from '@components/features/message/UserAvatar'
 import { formatRelativeDate } from '@utils/date'
+import ErrorBanner from '@components/ui/error-banner'
+
+export type LinkPreviewData = {
+    url: string
+    title?: string
+    description?: string
+    image?: string
+    site_name?: string
+}
+
+function parsePreviews(previewDataJson?: string): LinkPreviewData[] {
+    if (!previewDataJson) return []
+    try {
+        return JSON.parse(previewDataJson)
+    } catch {
+        return []
+    }
+}
+
+type RichPreview = {
+    link: SearchResult
+    preview: LinkPreviewData
+    index: number
+}
 
 const ChannelLinks = ({ channelID }: { channelID: string }) => {
     const { members } = useChannelMembers(channelID)
     const [searchQuery, setSearchQuery] = useState('')
-    const [showPreviews, setShowPreviews] = useState(false)
 
-    const { results, isLoading, error } = useSqliteSearch("", {
+    const { results, isLoading, error, mutate } = useSqliteSearch(searchQuery, {
         channel_id: channelID,
         has_link: 1
     }, 100)
 
+    useFrappeEventListener("link_previews_updated", (data: { channel_id: string }) => {
+        if (data.channel_id === channelID) {
+            mutate()
+        }
+    })
+
+    const { previews, previewlessUrls } = useMemo(() => {
+        const previews: RichPreview[] = []
+        const previewlessUrlSet = new Set<string>()
+
+        if (results) {
+            for (const link of results) {
+                for (const [index, preview] of parsePreviews(link.preview_data).entries()) {
+                    previews.push({ link, preview, index })
+                    if (!preview.title) {
+                        previewlessUrlSet.add(preview.url)
+                    }
+                }
+            }
+        }
+
+        return { previews, previewlessUrls: [...previewlessUrlSet] }
+    }, [results])
+
+    const { call: updatePreviewLinks } = useFrappePostCall('raven.api.preview_links.update_link_previews_in_background')
+    const backfillFired = useRef(false)
+
+    useEffect(() => {
+        if (previewlessUrls.length > 0 && !backfillFired.current) {
+            backfillFired.current = true
+            updatePreviewLinks({ urls: JSON.stringify(previewlessUrls), channel_id: channelID })
+        }
+    }, [previewlessUrls])
 
     return (
         <div className="px-1 space-y-2">
@@ -34,44 +90,25 @@ const ChannelLinks = ({ channelID }: { channelID: string }) => {
                         className="w-full pl-9 pr-4 py-2 text-sm bg-background border border-border/70 rounded-md focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
                     />
                 </div>
-
-                {/* View Toggle Button */}
-                <button
-                    onClick={() => setShowPreviews(!showPreviews)}
-                    className="p-2 text-muted-foreground hover:text-foreground hover:bg-muted rounded-md transition-colors"
-                    title={showPreviews ? "Switch to list view" : "Switch to preview view"}
-                >
-                    {showPreviews ? (
-                        <LayoutPanelTop className="w-4 h-4" />
-                    ) : (
-                        <Rows4 className="w-4 h-4" />
-                    )}
-                </button>
             </div>
-
+            {error && <ErrorBanner error={error} />}
             {/* Links List */}
             <ScrollArea className="flex-1">
                 {isLoading || !results ? <LinkPreviewSkeletonList /> :
-                    results.length === 0 ? <div className="text-sm text-muted-foreground text-center py-8">{_("No links shared in this channel yet.")}</div> :
-                    <div>
-                        <div className={`peer ${showPreviews ? 'space-y-3' : 'space-y-2'}`}>
-                            {results.flatMap((link) => {
+                    results.length === 0 ? <div className="text-sm text-muted-foreground text-center py-8">{searchQuery ? _("No links found matching your search.") : _("No links shared in this channel yet.")}</div> :
+                        <div className={'space-y-2'}>
+                            {previews.map(({ link, preview, index }) => {
                                 const member = members.find((m) => m.name === link.author)
-                                const urls = link.links?.split("|").filter(Boolean) || []
-                                return urls.map((url, index) => (
+                                return (
                                     <LinkPreviewCard
                                         key={`${link.id}-${index}`}
                                         link={link}
-                                        url={url}
+                                        preview={preview}
                                         member={member}
-                                        showPreviews={showPreviews}
-                                        searchQuery={searchQuery}
                                     />
-                                ))
+                                )
                             })}
-                        </div>
-                        {searchQuery && <div className="hidden peer-empty:block text-sm text-muted-foreground text-center py-8">{_("No links found matching your search.")}</div>}
-                    </div>}
+                        </div>}
             </ScrollArea>
         </div>
     )
@@ -102,132 +139,66 @@ const LinkPreviewSkeletonList = () => {
     return (
         <div className="flex w-full flex-1 flex-col lg:mx-auto space-y-2">
             {Array.from({ length: 6 }).map((_, i) => (
-                <LinkPreviewSkeleton i={i} />
+                <LinkPreviewSkeleton key={i} i={i} />
             ))}
         </div>
     )
 }
 
 
-
-const LinkPreviewCard = ({ link, url, member, showPreviews, searchQuery }: { link: SearchResult, url: string, member?: ChannelMemberData, showPreviews: boolean, searchQuery: string }) => {
-    const linkUrl = url
-    const { linkPreview, isLoading } = useLinkPreview(linkUrl)
+const LinkPreviewCard = ({ link, preview, member }: {
+    link: SearchResult,
+    preview: LinkPreviewData,
+    member?: ChannelMemberData,
+}) => {
+    const url = preview.url
     const hostname = new URL(url).hostname;
     const faviconUrl = `https://icons.duckduckgo.com/ip2/${hostname}.ico`;
+    const displayTitle = preview?.title || url
 
-    if (isLoading) {
-        return <LinkPreviewSkeleton />
-    }
-
-    const displayTitle = linkPreview?.title || linkUrl
-    if (searchQuery && !displayTitle.toLowerCase().includes(searchQuery.toLowerCase())) {
-        return null
-    }
     return (
         <div
-            key={link.id}
-            className={`group border border-border/70 rounded-lg hover:bg-muted/50 transition-colors cursor-pointer overflow-hidden max-w-87 ${!showPreviews ? 'p-3' : ''
-                }`}
+            key={link.id}   //TODO: Scroll to message when clicked, we have message id as link.name
+            className={`group border border-border/70 rounded-lg hover:bg-muted/50 transition-colors cursor-pointer overflow-hidden max-w-87 p-3`}
             tabIndex={0}
             role="button"
-            aria-label={`Open link: ${link.title}`}>
+            aria-label={`Open link: ${displayTitle}`}>
 
-            {showPreviews ? (
-                <div className="flex">
-                    {/* Preview Image */}
-                    {linkPreview?.image && (
-                        <div className="w-24 h-24 bg-muted/30 relative overflow-hidden shrink-0">
-                            <img
-                                src={linkPreview.image}
-                                alt={link.title}
-                                className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-200"
-                                onError={(e) => {
-                                    e.currentTarget.parentElement?.classList.add('hidden')
-                                }}
-                            />
-                            <div className="absolute inset-0 bg-linear-to-t from-black/10 to-transparent" />
-                        </div>
-                    )}
-
-                    {/* Content */}
-                    <div className="flex-1 p-3 min-w-0 flex flex-col justify-between">
-                        {/* Top section: Title and domain */}
-                        <div className="flex-1 min-w-0">
-                            <div className="flex items-center gap-2">
-                                {faviconUrl ? (
-                                    <img
-                                        src={faviconUrl}
-                                        alt=""
-                                        className="w-4 h-4 shrink-0"
-                                        onError={(e) => {
-                                            e.currentTarget.style.display = 'none';
-                                            e.currentTarget.nextElementSibling?.classList.remove('hidden');
-                                        }}
-                                    />
-                                ) : null}
-                                <Link className="w-4 h-4 shrink-0 text-muted-foreground hidden" />
-                                <h3 className="text-sm font-medium text-foreground line-clamp-1">
-                                    {linkPreview && linkPreview.title ? linkPreview.title : linkUrl}
-                                </h3>
-                                <ExternalLink className="h-3 w-3 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity duration-200 shrink-0 ml-auto" />
-                            </div>
-                            <div className="text-xs text-muted-foreground/60 mt-1">
-                                {linkPreview && linkPreview.site_name ? linkPreview.site_name : hostname}
-                            </div>
-                        </div>
-
-                        {/* Bottom section: User info */}
-                        <div className="flex items-center gap-2 text-xs text-muted-foreground/80 mt-2">
-                            {member && <> <UserAvatar
-                                user={member}
-                                size="xs"
-                                showStatusIndicator={false}
-                            />
-                                <span>{member.full_name}</span>
-                                <span>•</span></>}
-                            <span>{formatRelativeDate(link.creation)}</span>
+            <div className="space-y-2">
+                <div className="flex items-start gap-3">
+                    {faviconUrl ? (
+                        <img
+                            src={faviconUrl}
+                            alt=""
+                            className="w-5 h-5 shrink-0 mt-0.5"
+                            onError={(e) => {
+                                e.currentTarget.style.display = 'none';
+                                e.currentTarget.nextElementSibling?.classList.remove('hidden');
+                            }}
+                        />)
+                        : null}
+                    <Link className="w-5 h-5 shrink-0 text-muted-foreground mt-0.5 hidden" />
+                    <div className="flex-1 min-w-0">
+                        <h3 className="text-sm font-medium text-foreground truncate">
+                            {displayTitle}
+                        </h3>
+                        <div className="text-xs text-muted-foreground/70 mt-0.5">
+                            {preview?.site_name || hostname}
                         </div>
                     </div>
+                    <ExternalLink className="h-3 w-3 text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-primary transition-opacity duration-200 shrink-0 mt-0.5" onClick={() => window.open(url, '_blank')} />
                 </div>
-            ) : (
-                /* Compact List View */
-                <div className="space-y-2">
-                    <div className="flex items-start gap-3">
-                        {faviconUrl ? (
-                            <img
-                                src={faviconUrl}
-                                alt=""
-                                className="w-5 h-5 shrink-0 mt-0.5"
-                                onError={(e) => {
-                                    e.currentTarget.style.display = 'none';
-                                    e.currentTarget.nextElementSibling?.classList.remove('hidden');
-                                }}
-                            />)
-                            : null}
-                        <Link className="w-5 h-5 shrink-0 text-muted-foreground mt-0.5 hidden" />
-                        <div className="flex-1 min-w-0">
-                            <h3 className="text-sm font-medium text-foreground truncate">
-                                {linkPreview && linkPreview.title ? linkPreview.title : linkUrl}
-                            </h3>
-                            <div className="text-xs text-muted-foreground/70 mt-0.5">
-                                {linkPreview && linkPreview.site_name ? linkPreview.site_name : hostname}
-                            </div>
-                        </div>
-                        <ExternalLink className="h-3 w-3 text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-primary transition-opacity duration-200 shrink-0 mt-0.5" onClick={() => window.open(url, '_blank')} />
-                    </div>
-                    <div className="flex items-center gap-2 text-xs text-muted-foreground/80 ml-8">
-                        {member && <> <UserAvatar
-                            user={member}
-                            size="xs"
-                            showStatusIndicator={false}
-                        />
-                            <span>{member.full_name}</span>
-                            <span>•</span></>}
-                        <span>{formatRelativeDate(link.creation)}</span>
-                    </div>
+                <div className="flex items-center gap-2 text-xs text-muted-foreground/80 ml-8">
+                    {member && <> <UserAvatar
+                        user={member}
+                        size="xs"
+                        showStatusIndicator={false}
+                    />
+                        <span>{member.full_name}</span>
+                        <span>•</span></>}
+                    <span>{formatRelativeDate(link.creation)}</span>
                 </div>
-            )}
+            </div>
         </div>
     )
 }

--- a/apps/web/src/components/features/channel/CreateChannel/CreateChannelForm.tsx
+++ b/apps/web/src/components/features/channel/CreateChannel/CreateChannelForm.tsx
@@ -135,7 +135,7 @@ export const CreateChannelForm = ({ onClose: onCloseCallback, selectedWorkspace 
                                     ...data.message.channels,
                                     {
                                         ...result.message,
-                                        is_admin: '1',
+                                        is_admin: 1 as 1 | 0,
                                     }
                                 ]
                             }
@@ -269,75 +269,75 @@ export const CreateChannelForm = ({ onClose: onCloseCallback, selectedWorkspace 
                     {/* Footer - Sticky at Bottom */}
                     <div className="border-t bg-background">
                         <div className="px-4 py-4">
-                            {channelType !== "Open" ? 
-                            (currentStep === 1 ? (
-                                <div className="flex items-center justify-between gap-3" role="group" aria-label="Form navigation">
-                                    <Button
-                                        type="button"
-                                        variant="ghost"
-                                        onClick={() => onClose()}
-                                        disabled={isSubmitting}
-                                        className="text-sm px-4"
-                                        aria-label="Cancel channel creation"
-                                    >
-                                        {_('Cancel')}
-                                    </Button>
-                                    <div className="flex items-center">
+                            {channelType !== "Open" ?
+                                (currentStep === 1 ? (
+                                    <div className="flex items-center justify-between gap-3" role="group" aria-label="Form navigation">
                                         <Button
                                             type="button"
-                                            onClick={handleNext}
-                                            className="text-sm pl-5 pr-4"
-                                            aria-label="Proceed to add members step"
+                                            variant="ghost"
+                                            onClick={() => onClose()}
+                                            disabled={isSubmitting}
+                                            className="text-sm px-4"
+                                            aria-label="Cancel channel creation"
                                         >
-                                            {_('Add Members')}
-                                            <ArrowRightIcon className="ml-2 h-4 w-4" aria-hidden="true" />
+                                            {_('Cancel')}
+                                        </Button>
+                                        <div className="flex items-center">
+                                            <Button
+                                                type="button"
+                                                onClick={handleNext}
+                                                className="text-sm pl-5 pr-4"
+                                                aria-label="Proceed to add members step"
+                                            >
+                                                {_('Add Members')}
+                                                <ArrowRightIcon className="ml-2 h-4 w-4" aria-hidden="true" />
+                                            </Button>
+                                        </div>
+                                    </div>
+                                ) : (
+                                    <div className="flex items-center justify-between gap-3" role="group" aria-label="Form navigation">
+                                        <Button
+                                            type="button"
+                                            variant="ghost"
+                                            onClick={handleBack}
+                                            disabled={isSubmitting}
+                                            className="text-sm pl-3 pr-4"
+                                            aria-label="Go back to channel details"
+                                        >
+                                            <ArrowLeftIcon className="mr-2 h-4 w-4" aria-hidden="true" />
+                                            {_('Back')}
+                                        </Button>
+                                        <Button
+                                            onClick={handleSubmit(onSubmit)}
+                                            disabled={isSubmitting}
+                                            className="text-sm px-5"
+                                            aria-label={`Create channel with ${selectedMembers.length + 1} member${selectedMembers.length + 1 !== 1 ? 's' : ''}`}
+                                        >
+                                            {isSubmitting ? _('Creating...') : _(`Create Channel with ${selectedMembers.length + 1} member${selectedMembers.length + 1 !== 1 ? 's' : ''}`)}
                                         </Button>
                                     </div>
-                                </div>
-                            ) : (
-                                <div className="flex items-center justify-between gap-3" role="group" aria-label="Form navigation">
-                                    <Button
-                                        type="button"
-                                        variant="ghost"
-                                        onClick={handleBack}
-                                        disabled={isSubmitting}
-                                        className="text-sm pl-3 pr-4"
-                                        aria-label="Go back to channel details"
-                                    >
-                                        <ArrowLeftIcon className="mr-2 h-4 w-4" aria-hidden="true" />
-                                        {_('Back')}
-                                    </Button>
-                                    <Button
-                                        onClick={handleSubmit(onSubmit)}
-                                        disabled={isSubmitting}
-                                        className="text-sm px-5"
-                                        aria-label={`Create channel with ${selectedMembers.length + 1} member${selectedMembers.length + 1 !== 1 ? 's' : ''}`}
-                                    >
-                                        {isSubmitting ? _('Creating...') : _(`Create Channel with ${selectedMembers.length + 1} member${selectedMembers.length + 1 !== 1 ? 's' : ''}`)}
-                                    </Button>
-                                </div>
-                            )) : (
-                                <div className="flex items-center justify-between gap-3" role="group" aria-label="Form navigation">
-                                    <Button
-                                        type="button"
-                                        variant="ghost"
-                                        onClick={() => onClose()}
-                                        disabled={isSubmitting}
-                                        className="text-sm px-4"
-                                        aria-label="Cancel channel creation"
-                                    >
-                                        {_('Cancel')}
-                                    </Button>
-                                    <Button
-                                        onClick={handleSubmit(onSubmit)}
-                                        disabled={isSubmitting}
-                                        className="text-sm px-5"
-                                        aria-label={`Create channel with ${selectedMembers.length + 1} member${selectedMembers.length + 1 !== 1 ? 's' : ''}`}
-                                    >
-                                        {isSubmitting ? _('Creating...') : _(`Create Channel`)}
-                                    </Button>
-                                </div>
-                            )}    
+                                )) : (
+                                    <div className="flex items-center justify-between gap-3" role="group" aria-label="Form navigation">
+                                        <Button
+                                            type="button"
+                                            variant="ghost"
+                                            onClick={() => onClose()}
+                                            disabled={isSubmitting}
+                                            className="text-sm px-4"
+                                            aria-label="Cancel channel creation"
+                                        >
+                                            {_('Cancel')}
+                                        </Button>
+                                        <Button
+                                            onClick={handleSubmit(onSubmit)}
+                                            disabled={isSubmitting}
+                                            className="text-sm px-5"
+                                            aria-label={`Create channel with ${selectedMembers.length + 1} member${selectedMembers.length + 1 !== 1 ? 's' : ''}`}
+                                        >
+                                            {isSubmitting ? _('Creating...') : _(`Create Channel`)}
+                                        </Button>
+                                    </div>
+                                )}
                         </div>
                     </div>
                 </form>

--- a/apps/web/src/components/features/channel/CreateChannel/useChannelTypeInfo.ts
+++ b/apps/web/src/components/features/channel/CreateChannel/useChannelTypeInfo.ts
@@ -19,7 +19,7 @@ export const useChannelTypeInfo = (channelType: RavenChannel['type']) => {
             default:
                 return {
                     header: _('Create a public channel'),
-                    helperText: _('When a channel is set to public, anyone can join the channel and read messages, but only members can post messages.'),
+                    helperText: _('When a channel is set to public, anyone can read messages, join channel to post messages.'),
                 }
         }
     }, [channelType])

--- a/apps/web/src/hooks/useSqliteSearch.ts
+++ b/apps/web/src/hooks/useSqliteSearch.ts
@@ -24,8 +24,8 @@ export type SearchResult = {
     file_type?: string;
     file_size?: number;
     internal_link?: string;
-    links?: string;
     has_link?: 1 | 0;
+    preview_data?: string;
 };
 
 export const useSqliteSearch = (query: string, filters: Record<string, string | number | boolean | string[]>, limit: number = 20) => {

--- a/raven/api/preview_links.py
+++ b/raven/api/preview_links.py
@@ -94,13 +94,13 @@ def hide_link_preview(message_id: str):
 
 @frappe.whitelist(methods=["POST"])
 def update_link_previews_in_background(urls: list[str] | str, channel_id: str | None = None):
-	job_id = "update_link_previews"
+	job_id = f"update_link_previews_{channel_id}"
 	if not is_job_enqueued(job_id):
 		enqueue(
-			method=update_link_previews, urls=urls, channel_id=channel_id, job_name="update_link_previews"
+			method=update_link_previews, urls=urls, channel_id=channel_id, job_name=job_id
 		)
 	else:
-		frappe.log_error("Update preview links job is already running")
+		frappe.log_error(f"Update preview links job is already running for channel {channel_id}")
 
 
 def update_link_previews(urls: list[str] | str, channel_id: str | None = None):
@@ -114,10 +114,19 @@ def update_link_previews(urls: list[str] | str, channel_id: str | None = None):
 
 	for url in urls:
 		try:
-			preview_doc = frappe.get_doc("Raven Link Preview", url)
-			preview_doc.fetch_preview()
-			preview_doc.save()
-
+			if frappe.db.exists("Raven Link Preview", url):
+				preview_doc = frappe.get_doc("Raven Link Preview", url)
+				preview_doc.fetch_preview()
+				preview_doc.save()
+			else:
+				preview_doc = frappe.get_doc(
+					{
+						"doctype": "Raven Link Preview",
+						"url": url,
+					}
+				)
+				preview_doc.insert()
+				
 			# Re-index all messages that reference this URL
 			linked_messages = frappe.get_all(
 				"Raven Message Links", filters={"url": url, "parenttype": "Raven Message"}, pluck="parent"

--- a/raven/api/preview_links.py
+++ b/raven/api/preview_links.py
@@ -96,9 +96,7 @@ def hide_link_preview(message_id: str):
 def update_link_previews_in_background(urls: list[str] | str, channel_id: str | None = None):
 	job_id = f"update_link_previews_{channel_id}"
 	if not is_job_enqueued(job_id):
-		enqueue(
-			method=update_link_previews, urls=urls, channel_id=channel_id, job_name=job_id
-		)
+		enqueue(method=update_link_previews, urls=urls, channel_id=channel_id, job_name=job_id)
 	else:
 		frappe.log_error(f"Update preview links job is already running for channel {channel_id}")
 
@@ -126,7 +124,7 @@ def update_link_previews(urls: list[str] | str, channel_id: str | None = None):
 					}
 				)
 				preview_doc.insert()
-				
+
 			# Re-index all messages that reference this URL
 			linked_messages = frappe.get_all(
 				"Raven Message Links", filters={"url": url, "parenttype": "Raven Message"}, pluck="parent"

--- a/raven/api/preview_links.py
+++ b/raven/api/preview_links.py
@@ -3,7 +3,10 @@ import re
 
 import frappe
 from frappe import _
+from frappe.utils.background_jobs import enqueue, is_job_enqueued
 from linkpreview import Link, LinkGrabber, LinkPreview, link_preview
+
+from raven.utils import get_raven_room
 
 
 @frappe.whitelist(methods=["GET"])
@@ -87,3 +90,47 @@ def hide_link_preview(message_id: str):
 	message.hide_link_preview = 1
 	message.flags.editing_metadata = True
 	message.save()
+
+
+@frappe.whitelist(methods=["POST"])
+def update_link_previews_in_background(urls: list[str] | str, channel_id: str | None = None):
+	job_id = "update_link_previews"
+	if not is_job_enqueued(job_id):
+		enqueue(
+			method=update_link_previews, urls=urls, channel_id=channel_id, job_name="update_link_previews"
+		)
+	else:
+		frappe.log_error("Update preview links job is already running")
+
+
+def update_link_previews(urls: list[str] | str, channel_id: str | None = None):
+	if isinstance(urls, str) and urls != "[]":
+		urls = json.loads(urls)
+
+	from raven.api.search import RavenSearch
+
+	search = RavenSearch()
+	reindexed_messages = set()
+
+	for url in urls:
+		try:
+			preview_doc = frappe.get_doc("Raven Link Preview", url)
+			preview_doc.fetch_preview()
+			preview_doc.save()
+
+			# Re-index all messages that reference this URL
+			linked_messages = frappe.get_all(
+				"Raven Message Links", filters={"url": url, "parenttype": "Raven Message"}, pluck="parent"
+			)
+			for message_name in linked_messages:
+				if message_name not in reindexed_messages:
+					reindexed_messages.add(message_name)
+					search.index_doc("Raven Message", message_name)
+
+		except Exception:
+			frappe.log_error(f"Failed to update preview for {url}")
+
+	if channel_id:
+		frappe.publish_realtime(
+			"link_previews_updated", {"channel_id": channel_id}, room=get_raven_room()
+		)

--- a/raven/api/search.py
+++ b/raven/api/search.py
@@ -33,7 +33,7 @@ class RavenSearch(SQLiteSearch):
 			"file_thumbnail",  # this won't be here when we have a child table for files
 			"thumbnail_width",  # this won't be here when we have a child table for files
 			"thumbnail_height",  # this won't be here when we have a child table for files
-			"internal_link",  # this won't be here when we have a child table for files, and linked documents will go in Raven Link Preview
+			"internal_link",  # this won't be here when we have a child table for files
 			"preview_data",
 			"has_link",
 		],
@@ -86,9 +86,9 @@ class RavenSearch(SQLiteSearch):
 			.where(msg_link.parenttype == "Raven Message")
 		).run(pluck="url")
 
+		preview_data = []
+		preview_texts = []
 		if preview_urls:
-			preview_texts = []
-			preview_data = []
 			unique_urls = set(preview_urls)
 			for url in unique_urls:
 				preview = frappe.db.get_value(
@@ -111,29 +111,41 @@ class RavenSearch(SQLiteSearch):
 							"site_name": preview.get("site_name"),
 						}
 					)
+				else:
+					preview_data.append(
+						{
+							"url": url,
+						}
+					)
 
-			doc.has_link = 1
-
-			if preview_data:
-				doc.preview_data = json.dumps(preview_data)
-
-			if preview_texts:
-				doc.preview_search_text = "\n\n" + "\n".join(preview_texts)
-
-		link_document = None
 		if doc.link_document:
 			link_document = get_preview_data(doc.link_doctype, doc.link_document)
-			lowerCaseDoctype = doc.link_doctype.lower().replace(" ", "-")
-			doc.internal_link = f"/app/{lowerCaseDoctype}/{doc.link_document}"
-			if not doc.content:
-				doc.content = link_document.get("preview_title")
+			if link_document:
+				if link_document.get("preview_title"):
+					preview_texts.append(link_document.get("preview_title"))
+				if link_document.get("id"):
+					preview_texts.append(link_document.get("id"))
+				preview_data.append(
+					{
+						"url": link_document.get("raven_document_link"),
+						"title": link_document.get("preview_title"),
+						"image": link_document.get("preview_image"),
+						"document_id": link_document.get("id")
+					}
+				)
+
+
+		if preview_data:
+			doc.has_link = 1
+			doc.preview_data = json.dumps(preview_data)
+
+		if preview_texts:
+			doc.preview_search_text = "\n\n" + "\n".join(preview_texts)
+
 
 		document = super().prepare_document(doc)
 		if not document:
 			return None
-
-		if link_document:
-			document["title"] = link_document.get("preview_title")
 
 		is_thread = frappe.db.get_value("Raven Channel", doc.channel_id, "is_thread")
 		mentions = frappe.db.get_all("Raven Mention", {"parent": doc.name}, pluck="user")

--- a/raven/api/search.py
+++ b/raven/api/search.py
@@ -15,7 +15,7 @@ class RavenSearch(SQLiteSearch):
 
 	# Define the search schema
 	INDEX_SCHEMA = {
-		"text_fields": ["title", "content"],
+		"text_fields": ["title", "content", "preview_search_text"],
 		"metadata_fields": [
 			"channel_id",
 			"owner",
@@ -27,24 +27,23 @@ class RavenSearch(SQLiteSearch):
 			"is_bot_message",
 			"bot",
 			"poll_id",
-			"file_type",
-			"file_size",
-			"blurhash",
-			"file_thumbnail",
-			"thumbnail_width",
-			"thumbnail_height",
-			"internal_link",
-			"links",
+			"file_type",  # this won't be here when we have a child table for files
+			"file_size",  # this won't be here when we have a child table for files
+			"blurhash",  # this won't be here when we have a child table for files
+			"file_thumbnail",  # this won't be here when we have a child table for files
+			"thumbnail_width",  # this won't be here when we have a child table for files
+			"thumbnail_height",  # this won't be here when we have a child table for files
+			"internal_link",  # this won't be here when we have a child table for files, and linked documents will go in Raven Link Preview
+			"preview_data",
 			"has_link",
 		],
-		"tokenizer": "unicode61 remove_diacritics 2 tokenchars '-_'",
+		"tokenizer": "unicode61 remove_diacritics 2 tokenchars '-_.'",
 	}
 
 	# Define which doctypes to index and their field mappings
 	INDEXABLE_DOCTYPES = {
 		"Raven Message": {
 			"fields": [
-				"name",
 				"content",
 				"channel_id",
 				"owner",
@@ -59,11 +58,10 @@ class RavenSearch(SQLiteSearch):
 				"file_thumbnail",
 				"thumbnail_width",
 				"thumbnail_height",
-				"links",
 				"link_doctype",
 				"link_document",
 			],
-		},
+		}
 	}
 
 	def get_search_filters(self):
@@ -79,6 +77,49 @@ class RavenSearch(SQLiteSearch):
 
 	def prepare_document(self, doc):
 		"""Custom document preparation"""
+
+		msg_link = frappe.qb.DocType("Raven Message Links")
+		preview_urls = (
+			frappe.qb.from_(msg_link)
+			.select(msg_link.url)
+			.where(msg_link.parent == doc.name)
+			.where(msg_link.parenttype == "Raven Message")
+		).run(pluck="url")
+
+		if preview_urls:
+			preview_texts = []
+			preview_data = []
+			unique_urls = set(preview_urls)
+			for url in unique_urls:
+				preview = frappe.db.get_value(
+					"Raven Link Preview", url, ["title", "description", "image", "site_name"], as_dict=True
+				)
+				if preview:
+					if preview.get("title"):
+						preview_texts.append(preview.title)
+					if preview.get("description"):
+						preview_texts.append(preview.description)
+					if preview.get("site_name"):
+						preview_texts.append(preview.site_name)
+
+					preview_data.append(
+						{
+							"url": url,
+							"title": preview.get("title"),
+							"description": preview.get("description"),
+							"image": preview.get("image"),
+							"site_name": preview.get("site_name"),
+						}
+					)
+
+			doc.has_link = 1
+
+			if preview_data:
+				doc.preview_data = json.dumps(preview_data)
+
+			if preview_texts:
+				doc.preview_search_text = "\n\n" + "\n".join(preview_texts)
+
 		link_document = None
 		if doc.link_document:
 			link_document = get_preview_data(doc.link_doctype, doc.link_document)
@@ -105,8 +146,6 @@ class RavenSearch(SQLiteSearch):
 		else:
 			document["parent_channel_id"] = doc.channel_id
 
-		document["has_link"] = 1 if doc.links else 0
-
 		if doc.message_type == "File" or doc.message_type == "Image":
 			file_name = doc.file.split("/")[-1]
 			file_type = mimetypes.guess_type(file_name)[0]
@@ -123,10 +162,15 @@ class RavenSearch(SQLiteSearch):
 		return document
 
 	def index_doc(self, doctype, name):
-		"""Override index_doc to handle custom fields properly"""
+		"""Override index_doc to handle field mappings properly"""
 		# Get the document
 		doc = frappe.db.get_value(doctype, name, self.INDEXABLE_DOCTYPES[doctype]["fields"], as_dict=1)
+		if not doc:
+			return
+
 		doc["doctype"] = doctype
+		doc["name"] = name
+
 		self.raise_if_not_indexed()
 		# Remove existing document first to prevent duplicates
 		self.remove_doc(doctype, name)
@@ -245,6 +289,7 @@ def sqlite_search(query: str | None = None, filters: str | None = None, limit: i
 @frappe.whitelist()
 def rebuild_search_index():
 	search = RavenSearch()
+	search.drop_index()
 	search.build_index()
 	return "Search index rebuilt"
 

--- a/raven/api/search.py
+++ b/raven/api/search.py
@@ -130,10 +130,9 @@ class RavenSearch(SQLiteSearch):
 						"url": link_document.get("raven_document_link"),
 						"title": link_document.get("preview_title"),
 						"image": link_document.get("preview_image"),
-						"document_id": link_document.get("id")
+						"document_id": link_document.get("id"),
 					}
 				)
-
 
 		if preview_data:
 			doc.has_link = 1
@@ -141,7 +140,6 @@ class RavenSearch(SQLiteSearch):
 
 		if preview_texts:
 			doc.preview_search_text = "\n\n" + "\n".join(preview_texts)
-
 
 		document = super().prepare_document(doc)
 		if not document:

--- a/raven/patches.txt
+++ b/raven/patches.txt
@@ -19,3 +19,4 @@ raven.patches.v2_6.fix_duplicate_dm_channels
 raven.patches.v2_7.clean_duplicate_poll_votes
 raven.patches.v2_7.migrate_poll_votes_to_poll_vote_selection
 raven.patches.v2_7.add_unique_constraint_on_poll_votes
+raven.patches.v3_0.migrate_links_to_table_in_messages

--- a/raven/patches/v3_0/migrate_links_to_table_in_messages.py
+++ b/raven/patches/v3_0/migrate_links_to_table_in_messages.py
@@ -1,0 +1,56 @@
+import frappe
+from raven.api.search import RavenSearch
+
+def execute():
+	"""
+	Migrate links from small text field to table in Raven Message doctype.
+	
+	This will also create a Raven Link Preview document for each unique link.
+	"""
+
+	raven_message = frappe.qb.DocType("Raven Message")
+	messages = (
+		frappe.qb.from_(raven_message)
+		.select(raven_message.name, raven_message.links)
+		.where(raven_message.links.isnotnull())
+		.where(raven_message.links != "")
+		.run(as_dict=True)
+	)
+
+	child_table_values = []
+	unique_links = set()
+
+	for msg in messages:
+		# Skip non-string links
+		if not msg.links or not isinstance(msg.links, str):
+			continue
+			
+		for url in msg.links.split("|"):
+			if not url:
+				continue
+				
+			if not frappe.db.exists("Raven Message Links", {"parent": msg.name, "url": url}):
+				unique_links.add((url, url))
+				child_table_values.append((
+					frappe.generate_hash(length=10),
+					msg.name,
+					'Raven Message',
+					'links',
+					url
+				))
+
+	if child_table_values:
+		frappe.db.bulk_insert(
+			"Raven Message Links",
+			fields=["name", "parent", "parenttype", "parentfield", "url"],
+			values=child_table_values,
+			ignore_duplicates=True
+		)
+
+	if unique_links:
+		frappe.db.bulk_insert(
+			"Raven Link Preview",
+			fields=["name", "url"],
+			values=unique_links,
+			ignore_duplicates=True
+		)

--- a/raven/patches/v3_0/migrate_links_to_table_in_messages.py
+++ b/raven/patches/v3_0/migrate_links_to_table_in_messages.py
@@ -1,10 +1,12 @@
 import frappe
+
 from raven.api.search import RavenSearch
+
 
 def execute():
 	"""
 	Migrate links from small text field to table in Raven Message doctype.
-	
+
 	This will also create a Raven Link Preview document for each unique link.
 	"""
 
@@ -24,33 +26,26 @@ def execute():
 		# Skip non-string links
 		if not msg.links or not isinstance(msg.links, str):
 			continue
-			
+
 		for url in msg.links.split("|"):
 			if not url:
 				continue
-				
+
 			if not frappe.db.exists("Raven Message Links", {"parent": msg.name, "url": url}):
 				unique_links.add((url, url))
-				child_table_values.append((
-					frappe.generate_hash(length=10),
-					msg.name,
-					'Raven Message',
-					'links',
-					url
-				))
+				child_table_values.append(
+					(frappe.generate_hash(length=10), msg.name, "Raven Message", "links", url)
+				)
 
 	if child_table_values:
 		frappe.db.bulk_insert(
 			"Raven Message Links",
 			fields=["name", "parent", "parenttype", "parentfield", "url"],
 			values=child_table_values,
-			ignore_duplicates=True
+			ignore_duplicates=True,
 		)
 
 	if unique_links:
 		frappe.db.bulk_insert(
-			"Raven Link Preview",
-			fields=["name", "url"],
-			values=unique_links,
-			ignore_duplicates=True
+			"Raven Link Preview", fields=["name", "url"], values=unique_links, ignore_duplicates=True
 		)

--- a/raven/raven_channel_management/doctype/raven_channel/raven_channel.py
+++ b/raven/raven_channel_management/doctype/raven_channel/raven_channel.py
@@ -251,7 +251,11 @@ class RavenChannel(Document):
 	def autoname(self):
 		if self.is_direct_message == 0 and self.is_thread == 0:
 			# Add workspace name to the channel name
-			self.name = self.workspace.lower().replace(" ", "-") + "-" + self.channel_name.strip().lower().replace(" ", "-")
+			self.name = (
+				self.workspace.lower().replace(" ", "-")
+				+ "-"
+				+ self.channel_name.strip().lower().replace(" ", "-")
+			)
 		elif self.is_thread:
 			self.name = self.channel_name
 

--- a/raven/raven_channel_management/doctype/raven_channel/raven_channel.py
+++ b/raven/raven_channel_management/doctype/raven_channel/raven_channel.py
@@ -251,7 +251,7 @@ class RavenChannel(Document):
 	def autoname(self):
 		if self.is_direct_message == 0 and self.is_thread == 0:
 			# Add workspace name to the channel name
-			self.name = self.workspace + "-" + self.channel_name.strip().lower().replace(" ", "-")
+			self.name = self.workspace.lower().replace(" ", "-") + "-" + self.channel_name.strip().lower().replace(" ", "-")
 		elif self.is_thread:
 			self.name = self.channel_name
 

--- a/raven/raven_messaging/doctype/raven_link_preview/raven_link_preview.js
+++ b/raven/raven_messaging/doctype/raven_link_preview/raven_link_preview.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2026, The Commit Company (Algocode Technologies Pvt. Ltd.) and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Raven Link Preview", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/raven/raven_messaging/doctype/raven_link_preview/raven_link_preview.json
+++ b/raven/raven_messaging/doctype/raven_link_preview/raven_link_preview.json
@@ -1,0 +1,81 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:url",
+ "creation": "2026-04-10 15:05:48.216945",
+ "default_view": "List",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "title",
+  "description",
+  "image",
+  "site_name",
+  "document_id",
+  "url"
+ ],
+ "fields": [
+  {
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Title"
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "label": "Description"
+  },
+  {
+   "fieldname": "image",
+   "fieldtype": "Attach Image",
+   "label": "Image"
+  },
+  {
+   "fieldname": "site_name",
+   "fieldtype": "Data",
+   "label": "Site Name"
+  },
+  {
+   "fieldname": "url",
+   "fieldtype": "Data",
+   "label": "URL",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "document_id",
+   "fieldtype": "Data",
+   "label": "Document ID"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-04-10 15:43:57.967166",
+ "modified_by": "Administrator",
+ "module": "Raven Messaging",
+ "name": "Raven Link Preview",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "title"
+}

--- a/raven/raven_messaging/doctype/raven_link_preview/raven_link_preview.json
+++ b/raven/raven_messaging/doctype/raven_link_preview/raven_link_preview.json
@@ -11,7 +11,6 @@
   "description",
   "image",
   "site_name",
-  "document_id",
   "url"
  ],
  "fields": [
@@ -42,18 +41,13 @@
    "label": "URL",
    "reqd": 1,
    "unique": 1
-  },
-  {
-   "fieldname": "document_id",
-   "fieldtype": "Data",
-   "label": "Document ID"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-04-10 15:43:57.967166",
- "modified_by": "Administrator",
+ "modified": "2026-04-15 14:14:14.620869",
+ "modified_by": "aditya.p@frappe.io",
  "module": "Raven Messaging",
  "name": "Raven Link Preview",
  "naming_rule": "By fieldname",

--- a/raven/raven_messaging/doctype/raven_link_preview/raven_link_preview.py
+++ b/raven/raven_messaging/doctype/raven_link_preview/raven_link_preview.py
@@ -18,7 +18,6 @@ class RavenLinkPreview(Document):
 		from frappe.types import DF
 
 		description: DF.SmallText | None
-		document_id: DF.Data | None
 		image: DF.AttachImage | None
 		site_name: DF.Data | None
 		title: DF.Data | None

--- a/raven/raven_messaging/doctype/raven_link_preview/raven_link_preview.py
+++ b/raven/raven_messaging/doctype/raven_link_preview/raven_link_preview.py
@@ -58,4 +58,3 @@ class RavenLinkPreview(Document):
 
 	def before_insert(self):
 		self.fetch_preview()
-		

--- a/raven/raven_messaging/doctype/raven_link_preview/raven_link_preview.py
+++ b/raven/raven_messaging/doctype/raven_link_preview/raven_link_preview.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2026, The Commit Company (Algocode Technologies Pvt. Ltd.) and contributors
+# For license information, please see license.txt
+
+import re
+from urllib.parse import urljoin
+
+from frappe.model.document import Document
+from linkpreview import Link, LinkGrabber, LinkPreview, link_preview
+
+
+class RavenLinkPreview(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		description: DF.SmallText | None
+		document_id: DF.Data | None
+		image: DF.AttachImage | None
+		site_name: DF.Data | None
+		title: DF.Data | None
+		url: DF.Data
+	# end: auto-generated types
+
+	def fetch_preview(self):
+		if not (
+			self.url.startswith("mailto")
+			or self.url.startswith("tel")
+			or re.match(r"http://\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/.*", self.url)
+			or re.match(r"https://\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/.*", self.url)
+			or re.match(r"http://\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}", self.url)
+			or re.match(r"https://\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}", self.url)
+		):
+			preview = None
+			try:
+				# If this is a Twitter/X URL, then we need to fetch the preview from the Twitter API
+				# This is because the linkpreview library doesn't support Twitter previews with the default bot
+				if "twitter.com" in self.url or "x.com" in self.url:
+					grabber = LinkGrabber()
+					content, url_fetched = grabber.get_content(self.url, headers="imessagebot")
+					link = Link(url_fetched, content)
+					preview = LinkPreview(link)
+				else:
+					preview = link_preview(self.url)
+			except Exception:
+				preview = None
+				pass
+			if preview:
+				self.title = (preview.title or "")[:140]
+				self.description = preview.description
+				self.site_name = (preview.site_name or "")[:140]
+
+				if preview.image:
+					self.image = urljoin(self.url, preview.image)
+
+	def before_insert(self):
+		self.fetch_preview()
+		

--- a/raven/raven_messaging/doctype/raven_link_preview/test_raven_link_preview.py
+++ b/raven/raven_messaging/doctype/raven_link_preview/test_raven_link_preview.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2026, The Commit Company (Algocode Technologies Pvt. Ltd.) and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase
+
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+
+class IntegrationTestRavenLinkPreview(IntegrationTestCase):
+	"""
+	Integration tests for RavenLinkPreview.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/raven/raven_messaging/doctype/raven_link_preview/test_raven_link_preview.py
+++ b/raven/raven_messaging/doctype/raven_link_preview/test_raven_link_preview.py
@@ -4,13 +4,11 @@
 # import frappe
 from frappe.tests import IntegrationTestCase
 
-
 # On IntegrationTestCase, the doctype test records and all
 # link-field test record dependencies are recursively loaded
 # Use these module variables to add/remove to/from that list
 EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
-
 
 
 class IntegrationTestRavenLinkPreview(IntegrationTestCase):

--- a/raven/raven_messaging/doctype/raven_message/raven_message.json
+++ b/raven/raven_messaging/doctype/raven_message/raven_message.json
@@ -206,14 +206,15 @@
   },
   {
    "fieldname": "links",
-   "fieldtype": "Small Text",
-   "label": "Links"
+   "fieldtype": "Table",
+   "label": "Links",
+   "options": "Raven Message Links"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-01-31 13:55:57.988161",
- "modified_by": "Administrator",
+ "modified": "2026-04-13 14:22:34.038919",
+ "modified_by": "aditya.p@frappe.io",
  "module": "Raven Messaging",
  "name": "Raven Message",
  "naming_rule": "Random",

--- a/raven/raven_messaging/doctype/raven_message/raven_message.py
+++ b/raven/raven_messaging/doctype/raven_message/raven_message.py
@@ -34,6 +34,7 @@ class RavenMessage(Document):
 	from typing import TYPE_CHECKING
 
 	if TYPE_CHECKING:
+		from frappe.model.document import Document
 		from frappe.types import DF
 
 		from raven.raven_messaging.doctype.raven_mention.raven_mention import RavenMention
@@ -56,7 +57,7 @@ class RavenMessage(Document):
 		link_doctype: DF.Link | None
 		link_document: DF.DynamicLink | None
 		linked_message: DF.Link | None
-		links: DF.SmallText | None
+		links: DF.Table[Document]
 		mentions: DF.Table[RavenMention]
 		message_reactions: DF.JSON | None
 		message_type: DF.Literal["Text", "Image", "File", "Poll", "System"]
@@ -84,7 +85,7 @@ class RavenMessage(Document):
 		1. Extract all user mentions
 		2. Remove empty trailing paragraphs
 		3. Extract the text content
-		4. Extract all links and store as | separated string
+		4. Extract all links and create Raven Link Preview documents
 		"""
 		if not self.text:
 			return
@@ -95,13 +96,15 @@ class RavenMessage(Document):
 		self.remove_empty_trailing_paragraphs(soup)
 		self.extract_mentions(soup)
 
-		links = []
 		for link in soup.find_all("a"):
 			href = link.get("href")
 			if href:
-				links.append(href)
-		if links:
-			self.links = "|" + "|".join(links) + "|"
+				if not frappe.db.exists("Raven Link Preview", {"url": href}):
+					preview = frappe.new_doc("Raven Link Preview")
+					preview.url = href
+					preview.deferred_insert()
+
+				self.append("links", {"url": href})
 
 		text_content = soup.get_text(" ", strip=True)
 


### PR DESCRIPTION
- [x] Raven Link Preview doctype that fetches and stores preview data, created by message containing links
- [x] Store links in child table on Raven Message to link to respective Raven Link Preview docs
- [x] Sqlite search works on preview title and description
- [x] patch to migrate links on messages from `| separated strings` to child table
- [x] background job to fetch previews for old data when encountered
- [x] linked documents should also show up in search for links 

<img width="393" height="800" alt="CleanShot 2026-04-15 at 15 44 11" src="https://github.com/user-attachments/assets/62be186c-a0bb-42cd-81f5-7367b46e0256" />
